### PR TITLE
Upgrade to flux v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,26 +4,30 @@
   "description": "",
   "main": "gulpfile.js",
   "dependencies": {
-  "react": "^0.13.3",
-  "react-router": "^0.13.3",
-  "reactify": "0.17.1",
-  "superagent": "0.21.0"
-
+    "flux": "^2.0.3",
+    "react": "^0.13.3",
+    "react-router": "^0.13.3",
+    "superagent": "0.21.0",
+    "object-assign": "2.0.0" 
   },
+
   "devDependencies": {
     "envify": "^1.2.1",
     "es6-promise": "^1.0.0",
     "gulp": "^3.8.0",
-    "gulp-browserify": "^0.5.0",
+    "gulp-browserify": "^0.5.1",
     "gulp-concat": "^2.2.0",
     "gulp-connect": "^2.2.0",
     "gulp-open": "~0.3.2",
     "gulp-livereload": "^3.8.0",
-    "gulp-plumber": "^1.0.0"
+    "gulp-plumber": "^1.0.0",
+    "reactify": "1.1.1"
   },
+  
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "watch" : "gulp watch"
   },
+  
   "author": "",
   "license": "ISC"
 }

--- a/src/js/components/app-template.js
+++ b/src/js/components/app-template.js
@@ -21,7 +21,7 @@ var Template =
                     {this.props.children}
                     <br/><br/>
                     { /* this button component uses view action dispatcher api  and it is using flux architecture */ }
-                    <button className="btn btn-default" onClick={this.handleClick}>Add Item (an example output in the console .. it is using Actions->Dispatcher->Store one directional flow) </button>
+                    <button className="btn btn-default" onClick={this.handleClick}>Add Item (an example output in the console .. it is using Actions-&lt;Dispatcher-&lt;Store one directional flow) </button>
                 </div>
             	)
         }

--- a/src/js/dispatchers/app-dispatcher.js
+++ b/src/js/dispatchers/app-dispatcher.js
@@ -1,8 +1,9 @@
 /** @jsx React.DOM */
-var React = require('react/addons');
-var Dispatcher = require('./dispatcher.js');
 
-var AppDispatcher = React.addons.update(Dispatcher.prototype, { $merge: {
+var Dispatcher = require('flux').Dispatcher;
+var assign = require('object-assign');
+
+var AppDispatcher = assign(new Dispatcher(), {
   handleViewAction: function(action){
     console.log("*****start handleViewAction******");
     console.log(action);
@@ -30,6 +31,6 @@ var AppDispatcher = React.addons.update(Dispatcher.prototype, { $merge: {
       action: action
     })
   },
-}});
+});
 
 module.exports = AppDispatcher;


### PR DESCRIPTION
Upgraded project to use lastest version of flux.
List of changes: 

In `package.json`
- Switched from file version of flux to npm package of flux
- Moved reactify to devPackages 
- Added `gulp watch` to npm script

In `app-dispatcher.js`
- Require flux module instead of file
- Require `object-assign` for ponyfill  that doesn't overwrite the native method
